### PR TITLE
Include netcdf_variable_name in metadata call

### DIFF
--- a/backend/ce/api/metadata.py
+++ b/backend/ce/api/metadata.py
@@ -36,7 +36,7 @@ def metadata(sesh, model_id=None):
 
     rv = {}
     for f in files:
-        vars = [ { dfv.netcdf_variable_name: a.long_name } for a in [ dfv.variable_alias for dfv in f.data_file_variables ] ]
+        vars = [ { dfv.netcdf_variable_name: a.long_name } for a, dfv in [ (dfv.variable_alias, dfv) for dfv in f.data_file_variables ] ]
 
         rv[f.unique_id] = {
             'institution': f.run.model.organization,

--- a/backend/ce/api/metadata.py
+++ b/backend/ce/api/metadata.py
@@ -36,7 +36,7 @@ def metadata(sesh, model_id=None):
 
     rv = {}
     for f in files:
-        vars = [ a.long_name for a in [ v.variable_alias for v in f.data_file_variables ] ]
+        vars = [ { dfv.netcdf_variable_name: a.long_name } for a in [ dfv.variable_alias for dfv in f.data_file_variables ] ]
 
         rv[f.unique_id] = {
             'institution': f.run.model.organization,


### PR DESCRIPTION
netcdf_variable_name is required when requesting data/maps from supporting services.